### PR TITLE
Use small versioned docker image

### DIFF
--- a/builds/mongoDB/Dockerfile
+++ b/builds/mongoDB/Dockerfile
@@ -1,12 +1,12 @@
 # Filename: Dockerfile
 
-FROM ubuntu:20.04
+FROM node:lts-slim
 
 # Disable Prompt During Packages Installation
 ARG DEBIAN_FRONTEND=noninteractive
 
 #install dependencies
-RUN apt-get update && apt-get install -y nodejs npm nano mongo-tools && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y mongo-tools && rm -rf /var/lib/apt/lists/*
 
 #Add non-root user, add installation directories and assign proper permissions
 RUN mkdir -p /opt/meshcentral

--- a/builds/regular/Dockerfile
+++ b/builds/regular/Dockerfile
@@ -1,12 +1,9 @@
 # Filename: Dockerfile
 
-FROM ubuntu:20.04
+FROM node:lts-slim
 
 # Disable Prompt During Packages Installation
 ARG DEBIAN_FRONTEND=noninteractive
-
-#install dependencies
-RUN apt-get update && apt-get install -y nodejs npm nano && rm -rf /var/lib/apt/lists/*
 
 #Add non-root user, add installation directories and assign proper permissions
 RUN mkdir -p /opt/meshcentral


### PR DESCRIPTION
Some features of the MeshCentral requires the newest NodeJS versions. I suggest switch to the node images to control node versions and reduce image size.